### PR TITLE
Fix "Getting Started" link

### DIFF
--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ If you have not used Fyne before then the following steps will get you up and ru
 1. `go get fyne.io/fyne`
 
 For more details including the exact commands for your operating system see 
-the [getting started](http://localhost:4000/started/) page.
+the [getting started](/started/) page.
 
 ## Diving Right In
 


### PR DESCRIPTION
Baically the link to get started on https://developer.fyne.io/ lead to `localhost:4000` which is not valid for us users.

so this just edits that line to work properly.

My guess was an accidental artifact from someone not double checking thier work or a tool dun goofed