### PR TITLE
Update cross-compiling.md

### DIFF
--- a/started/cross-compiling.md
+++ b/started/cross-compiling.md
@@ -53,10 +53,16 @@ fyne-cross allows to build binaries and create distribution packages for the fol
 
 > Note: iOS compilation is supported only on darwin hosts.
 
+#### Requirements
+
+- go >= 1.13
+- docker
+- [module-aware mode](https://golang.org/ref/mod#mod-commands) enabled
+
 #### Installation
 
 ```
-go get github.com/lucor/fyne-cross/v2/cmd/fyne-cross
+GO111MODULE=on go get github.com/lucor/fyne-cross/v2/cmd/fyne-cross
 ```
 
 #### Usage


### PR DESCRIPTION
 Update fyne-cross installation step to work also when module-aware mode is not enabled and add requirements