### PR TITLE
Correct libXxf86vm package for Fedora

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -78,7 +78,7 @@ Note that these steps are just required for development - your Fyne applications
 * **Ubuntu / Debian:**
 `sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev`
 * **Fedora:**
-`sudo dnf install golang gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm`
+`sudo dnf install golang gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
 * **Solus:**
 `sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel`
 * **Arch Linux:**


### PR DESCRIPTION
# Context
For Fedora libXxf86vm-devel is what provides the symbolic link to libXxf86vm.so.1.0.0 which is provided by libXxf86vm. libXxf86vm is a dependency of libXxf86vm-devel and will be installed as well. Without the devel package you will run into the following error when trying to build a project.

```
# github.com/go-gl/glfw/v3.3/glfw
/usr/bin/ld: cannot find -lXxf86vm
collect2: error: ld returned 1 exit status
```

Output of `dnf provides` on my Fedora 32 system.
```
work@andrew-zbook-14u:~$ dnf provides '*libXxf86vm.so'
libXxf86vm-devel-1.1.4-13.fc32.i686 : X.Org X11 libXxf86vm development package
Repo        : fedora
Matched from:
Other       : *libXxf86vm.so

libXxf86vm-devel-1.1.4-13.fc32.x86_64 : X.Org X11 libXxf86vm development package
Repo        : @System
Matched from:
Other       : *libXxf86vm.so

libXxf86vm-devel-1.1.4-13.fc32.x86_64 : X.Org X11 libXxf86vm development package
Repo        : fedora
Matched from:
Other       : *libXxf86vm.so
```

# Overview of changes
- Switch libXxf86vm to libXxf86vm-devel in the Fedora Linux prerequisites section