### PR TITLE
The first tutorial is "Basics" in the menu.

### DIFF
--- a/tour/introduction/learning.md
+++ b/tour/introduction/learning.md
@@ -23,4 +23,4 @@ You can find more about contributing by visiting our
 [contributors page](https://fyne.io/contribute.html) or 
 [github repository](https://github.com/fyne-io/fyne/).
 
-Please continue to our first tutorial "[Getting Started](/tour/basics/)".
+Please continue to our first tutorial "[Basics](/tour/basics/)".


### PR DESCRIPTION
"Getting Started" is used for another section of the site while the first tutorial is listed as "Basics" and not "Getting Started".