### PR TITLE
NewVBox and NewHBox deprecated

### DIFF
--- a/_includes/tour/widget/box.go
+++ b/_includes/tour/widget/box.go
@@ -9,8 +9,8 @@ func main() {
 	myApp := app.New()
 	myWindow := myApp.NewWindow("Entry Widget")
 
-	content := widget.NewVBox(widget.NewLabel("The top row of VBox"),
-		widget.NewHBox(
+	content := container.NewVBox(widget.NewLabel("The top row of VBox"),
+		container.NewHBox(
 			widget.NewLabel("Label 1"),
 			widget.NewLabel("Label 2")))
 


### PR DESCRIPTION
As virtual and horizontal box deprecated in widget module I have replaced them with container.NewVBox() and container.NewHBox()