### PR TITLE
Fix Firefox x-overflow on landing.

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -32,8 +32,9 @@ div.deprecated {
     white-space: pre !important;
 }
 
-div.intro-row div {
-    padding-bottom: 30px;
+div.intro-row {
+    display: flex;
+    flex-flow: row nowrap;
 }
 
 ul.tabcontrol.tabs {


### PR DESCRIPTION
When I visited fyne's website a little while ago on the latest stable version of Firefox, I noticed severe x-overflow due to an `<hr>` being rendered inline with the `div.intro-row` on the fullscreen layout:

![severe overflow at intro row](https://user-images.githubusercontent.com/7704542/104632973-51d32b00-5653-11eb-87dc-bbedd8015c3e.png)

This is unlike Chrome, Edge, etc. which render it as expected. The source of the problem is the container's styles failing to account for floating children. This pull request changes the styles for `div.intro-row` to flexbox (row, nowrap) so that the contained cards have even spacing and so that the container is automatically sized to the maximum height child irrespective of float. The result looks like this on Firefox, and leaves the presentation on other browsers unmodified:

![overflow resolved](https://user-images.githubusercontent.com/7704542/104635741-2d794d80-5657-11eb-99c4-7c5b6be68486.png)