### PR TITLE
Increase contrast in code highlighting

### DIFF
--- a/css/syntax-base16.light.css
+++ b/css/syntax-base16.light.css
@@ -11,19 +11,19 @@
   color: #505050;
 }
 .highlight .cp {
-  color: #f4bf75;
+  color: #7b4c09;
 }
 .highlight .nt {
-  color: #f4bf75;
+  color: #7b4c09;
 }
 .highlight .o, .highlight .ow {
-  color: #d0d0d0;
+  color: #505050;
 }
 .highlight .p, .highlight .pi {
-  color: #d0d0d0;
+  color: #404040;
 }
 .highlight .gi {
-  color: #90a959;
+  color: #4b592f;
 }
 .highlight .gd {
   color: #ac4142;
@@ -34,19 +34,19 @@
   font-weight: bold;
 }
 .highlight .k, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kv {
-  color: #aa759f;
+  color: #75486d;
 }
 .highlight .kc {
-  color: #d28445;
+  color: #7f4a1f;
 }
 .highlight .kt {
-  color: #d28445;
+  color: #7f4a1f;
 }
 .highlight .kd {
-  color: #d28445;
+  color: #7f4a1f;
 }
 .highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .sh, .highlight .sx, .highlight .s1 {
-  color: #90a959;
+  color: #4b592f;
 }
 .highlight .sr {
   color: #75b5aa;
@@ -58,20 +58,20 @@
   color: #8f5536;
 }
 .highlight .nn {
-  color: #f4bf75;
+  color: #7b4c09;
 }
 .highlight .nc {
-  color: #f4bf75;
+  color: #7b4c09;
 }
 .highlight .no {
-  color: #f4bf75;
+  color: #7b4c09;
 }
 .highlight .na {
   color: #6a9fb5;
 }
 .highlight .m, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mb, .highlight .mx {
-  color: #90a959;
+  color: #4b592f;
 }
 .highlight .ss {
-  color: #90a959;
+  color: #4b592f;
 }

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -27,7 +27,7 @@
 .highlight .m { color: #009999 } /* Literal.Number */
 .highlight .s { color: #d14 } /* Literal.String */
 .highlight .na { color: #008080 } /* Name.Attribute */
-.highlight .nb { color: #0086B3 } /* Name.Builtin */
+.highlight .nb { color: #006080 } /* Name.Builtin */
 .highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
 .highlight .no { color: #008080 } /* Name.Constant */
 .highlight .ni { color: #800080 } /* Name.Entity */


### PR DESCRIPTION
This increases the code highlighting contrast ratio for
syntax-base16.light so that the syntax-highlighted code passes a
contrast check at the WCAG AAA level, which improves site
usability for visually impaired users.

While reading some of the code samples I had a hard time seeing
some elements -- especially punctuation. To make these changes
I used https://webaim.org/resources/contrastchecker/ to decrease
lightness just enough to pass at the WCAG AAA level. I wear
glasses but am not even close to "disabled" visually, and I find that
the site is much more easily readable at these levels, so I suspect
this will help quite a few other site users.

I checked a number of pages (but not _everything_) using the
plugin from https://wave.webaim.org/ and fixed up contrast for
everything I found in the syntax highlighting css. (But nothing in
other areas of pages that were flagged by that tool.) I also did not
look at the dark theme.