### PR TITLE
Fix bug / stay consistent in Layout interface code

### DIFF
--- a/tutorial/custom-layout.md
+++ b/tutorial/custom-layout.md
@@ -9,8 +9,8 @@ If you look at the code you will see that they all implement the `Layout` interf
 
 ```go
 type Layout interface {
-	Layout([]CanvasObject, Size)
-	MinSize(objects []CanvasObject) Size
+	Layout([]fyne.CanvasObject, fyne.Size)
+	MinSize(objects []fyne.CanvasObject) fyne.Size
 }
 ```
 


### PR DESCRIPTION
The original interface sample won't compile because it is missing the package name. The remainder of the sample code sections contain correct code and this proposed change makes the tutorial consistent.