### PR TITLE
Update BSD install tab for 2.1.2 of Fyne

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -166,7 +166,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
             clickTab("linux");
         } else if (os == "Linux armv7l") {
             clickTab("rpi");
-        } else if (os == "FreeBSD i386" || os == "FreeBSD amd64" || os == "OpenBSD i386" || os == "OpenBSD amd64" || os == "OpenBSD i386" || os == "NetBSD amd64") {
+        } else if (os == "FreeBSD i386" || os == "FreeBSD amd64" || os == "OpenBSD i386" || os == "OpenBSD amd64" || os == "NetBSD i386" || os == "NetBSD amd64") {
         	clickTab("bsd");
         }
     });

--- a/started/index.md
+++ b/started/index.md
@@ -119,9 +119,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 
 * You will need to install Go, gcc and the graphics library header files using the package manager.
 * **FreeBSD:**
-`sudo pkg install go gcc xorg glfw pkgconf`
-* **OpenBSD:**
-`sudo pkg_add go glfw`
+`sudo pkg install go gcc xorg pkgconf`
 </div>
 </div>
 
@@ -168,7 +166,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
             clickTab("linux");
         } else if (os == "Linux armv7l") {
             clickTab("rpi");
-        } else if (os == "FreeBSD i386" || os == "FreeBSD amd64") {
+        } else if (os == "FreeBSD i386" || os == "FreeBSD amd64" || os == "OpenBSD i386" || os == "OpenBSD amd64" || os == "OpenBSD i386" || os == "NetBSD amd64") {
         	clickTab("bsd");
         }
     });


### PR DESCRIPTION
Remove the glfw dep now that it isn't needed. I also removed the OpenBSD section as it was not working before and we don't advertise it working now either. Apart from that, I just made sure that we open the BSD tab for any BSD systems (useful in the future).