### PR TITLE
Add install steps for openSUSE

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -91,7 +91,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 <div style="text-align: left" markdown="1">
 
 * You will need to install Go, gcc and the graphics library header files using your package manager, one of the following commands will probably work.
-* **Ubuntu / Debian:**
+* **Debian / Ubuntu:**
 `sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev`
 * **Fedora:**
 `sudo dnf install golang gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
@@ -99,7 +99,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 `sudo pacman -S go xorg-server-devel`
 * **Solus:**
 `sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel`
-* **OpenSUSE:**
+* **openSUSE:**
 `sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
 * **Void Linux:**
 `sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel`

--- a/started/index.md
+++ b/started/index.md
@@ -95,10 +95,12 @@ The steps for installing with MSYS2 (recommended) are as follows:
 `sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev`
 * **Fedora:**
 `sudo dnf install golang gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
-* **Solus:**
-`sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel`
 * **Arch Linux:**
 `sudo pacman -S go xorg-server-devel`
+* **Solus:**
+`sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel`
+* **OpenSUSE:**
+`sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
 * **Void Linux:**
 `sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel`
 


### PR DESCRIPTION
Tested to work on openSUSE Tumbleweed. I am kind of amazed by the fact that no one (to my knowledge) have complained about it missing or opened a PR for it before. I also moved down Solus on the list. Seems like we get way more bug reports on Arch Linux, so it kind of made sense to bump it down on the list. Ubuntu is based on Debian, not the other way around, so I switched the words around as well.

![Screenshot from 2021-12-10 16-10-52](https://user-images.githubusercontent.com/25466657/145597526-8a5b085a-65f3-4f4b-ab8b-e634caa475f6.png)
 