### PR TITLE
Add missing Arch package dependecies

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -103,7 +103,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * **Fedora:**
 `sudo dnf install golang gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
 * **Arch Linux:**
-`sudo pacman -S go xorg-server-devel`
+`sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi`
 * **Solus:**
 `sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel`
 * **openSUSE:**


### PR DESCRIPTION
All of these packages are necessary to compile a program using Fyne on Arch -- in particular, on common Arch container (LXC) images.