### PR TITLE
Corrected a spelling mistake

### DIFF
--- a/container/center.md
+++ b/container/center.md
@@ -7,7 +7,7 @@ redirect_from:
 
 `layout.CenterLayout` organises all items in its container to be
 centered in the available space. The objects will be drawn in the order
-the are passed to the container, with the last being drawn top-most.
+they are passed to the container, with the last being drawn top-most.
 
 ```go
 package main


### PR DESCRIPTION
Corrected a spelling mistake: `in the order the are passed` -> `in the order they are passed`