### PR TITLE
Add link to fyne_demo code in Getting Started Docs

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -201,7 +201,7 @@ You do this by using the following command (can be skipped if you are not using 
 
 If you are unsure of how Go modules work, consider reading [Tutorial: Create a Go module](https://golang.org/doc/tutorial/create-module).
 
-## Run the [demo](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo)
+## Run the demo
 
 If you want to see the Fyne toolkit in action before you start to code your own application,
 you can see our [demo app](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo) running on your computer by executing:

--- a/started/index.md
+++ b/started/index.md
@@ -201,10 +201,10 @@ You do this by using the following command (can be skipped if you are not using 
 
 If you are unsure of how Go modules work, consider reading [Tutorial: Create a Go module](https://golang.org/doc/tutorial/create-module).
 
-## Run the demo
+## Run the [demo](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo)
 
 If you want to see the Fyne toolkit in action before you start to code your own application,
-you can see our demo app running on your computer by executing:
+you can see our [demo app](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo) running on your computer by executing:
 
     $ go run fyne.io/fyne/v2/cmd/fyne_demo
 


### PR DESCRIPTION
It took me a little bit to find the demo code when going through this part of the tutorial, and it'd be nice to have it linked for easy study.