### PR TITLE
Add install commands for OpenBSD and NetBSD

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -129,6 +129,10 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * You will need to install Go, gcc and the graphics library header files using the package manager.
 * **FreeBSD:**
 `sudo pkg install go gcc xorg pkgconf`
+* **OpenBSD:**
+`sudo pkg_add go`
+* **NetBSD:**
+`sudo pkgin install go pkgconf`
 </div>
 </div>
 


### PR DESCRIPTION
This PR adds install commands for OpenBSD and NetBSD and is intended to be merged as v2.2.0 go live. The installation steps for OpenBSD are based on what I removed in https://github.com/fyne-io/developer.fyne.io/pull/59 (minus the `glfw` dependency as that shouldn't be needed) and the NetBSD installation is based on https://github.com/fyne-io/fyne/pull/2676.