### PR TITLE
Add an issue template to avoid confusion

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+<!--
+This issue tracker is only intended for issues related to the https://developer.fyne.io/ site.
+Any issues related to the Fyne toolkit should instead be opened at https://github.com/fyne-io/fyne. 
+-->
+
+### Description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+contact_links:
+  - name: Ask a question
+    url: https://fyne.io/support/
+    about: For a toolkit question or help with your code go to our support page
+
+blank_issues_enabled: false


### PR DESCRIPTION
This creates a simple issue template that makes it clearer that this is the wrong place to open issues about Fyne.