### PR TITLE
Add package manager command for Alpine Linux

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -110,6 +110,8 @@ The steps for installing with MSYS2 (recommended) are as follows:
 `sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
 * **Void Linux:**
 `sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel`
+* **Alpine Linux**
+`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev mesa-dev`
 
 </div>
 </div>

--- a/started/index.md
+++ b/started/index.md
@@ -111,7 +111,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * **Void Linux:**
 `sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel`
 * **Alpine Linux**
-`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev mesa-dev`
+`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev linux-headers mesa-dev`
 
 </div>
 </div>


### PR DESCRIPTION
This PR adds a package manager command for Alpine Linux to the prerequisites section of Getting Started.

This list of dependencies has been tested via the [itgui-git](https://github.com/Arsen6331/lure-repo/blob/master/itgui-git/lure.sh) LURE package and is known to work.

I omitted the `linux-headers` dependency because it's needed on all distros but it seems not to be in any of the lists on the site, but that may just be because it's installed by default on those distros. If you'd like me to add it back, I can do that.