### PR TITLE
Fixed go get

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -198,12 +198,7 @@ Run the following command and replace `MODULE_NAME` with your preferred module n
 
 You now need to download the Fyne module. This will be done using the following command: 
 
-    $ go get fyne.io/fyne/v2
-
-To finish your module's set up, you now need to tidy the module file to correctly reference Fyne as a dependency.
-You do this by using the following command (can be skipped if you are not using modules):
-
-    $ go mod tidy
+    $ go get fyne.io/fyne/v2/...
 
 If you are unsure of how Go modules work, consider reading [Tutorial: Create a Go module](https://golang.org/doc/tutorial/create-module).
 


### PR DESCRIPTION
Doing `go get fyne.io/fyne/v2` and then `go mod tidy` in a fresh module without any .go file referencing the package does not work. The tidy will remove all packages from `go.mod`.

What works is to recursively fetch modules with `go get fyne.io/fyne/v2/...`. The demo can be run without any further steps. I verified this in Go 1.18 and 1.19 (previous versions don't compile on my Mac).