### PR TITLE
Fix a few broken install commands

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -199,7 +199,7 @@ Run the following command and replace `MODULE_NAME` with your preferred module n
 You now need to download the Fyne module and helper tool. This will be done using the following commands: 
 
     $ go get fyne.io/fyne/v2@latest
-    $ go get fyne.io/fyne/v2/cmd/fyne@latest
+    $ go install fyne.io/fyne/v2/cmd/fyne@latest
 
 If you are unsure of how Go modules work, consider reading [Tutorial: Create a Go module](https://golang.org/doc/tutorial/create-module).
 
@@ -228,9 +228,15 @@ If there are any problems with your installation see the [troubleshooting](/faq/
 If you want to see the Fyne toolkit in action before you start to code your own application,
 you can see our [demo app](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo) running on your computer by executing:
 
-    $ go run fyne.io/fyne/v2/cmd/fyne_demo
+    $ go run fyne.io/fyne/v2/cmd/fyne_demo@latest
 
 Please note that the first run has to compile some C-code and can thus take longer than usual. Subsequent builds reuse the cache and will be much faster.
+
+### Older Go version
+
+To run the demo on an older version of Go, simply execute the follwing command instead:
+
+    $ go run fyne.io/fyne/v2/cmd/fyne_demo
 
 ### Installing
 


### PR DESCRIPTION
One command was still referencing `go get` and another was not working using Go 1.19.