### PR TITLE
Add example of using SimpleRenderer for custom widgets.

### DIFF
--- a/extend/custom-widget.md
+++ b/extend/custom-widget.md
@@ -112,7 +112,7 @@ must be able to reflect the same widget state.
 
 #### Using SimpleRenderer for custom widgets
 
-Custom widgets built from a single `CanvasObject`, for example a container wrapping,
+Custom widgets built from a single `CanvasObject`, for example a container wrapping
 multiple builtin widgets, can be implemented using `SimpleRenderer`.
 Below example is a custom widget that can be used as item in a list view,
 showing a title on the left hand side that will be truncated when too long, and

--- a/extend/custom-widget.md
+++ b/extend/custom-widget.md
@@ -117,20 +117,32 @@ The following pattern can used to wrap existing widgets using the
 and change the content dynamically, and many more things are possible following
 this approach.
 
+Below example is a custom widget that can be used as item in a list view,
+showing a title on the left hand side that will be truncated when too long, and
+a comment on the right hand side. The constructor would be called from the
+`CreateItem` function of the list, and the title and comment changed in the
+`UpdateItem` function:
+
 ```go
-type MyCustomWidget struct
-    widget.BaseWidget
-    // all your widget's state, including its sub-widgets
+type MyListItemWidget struct {
+	widget.BaseWidget
+	Title   *widget.Label
+	Comment *widget.Label
 }
 
-func NewMyCustomWidget() *MyCustomWidget {
-    w := &MyCustomWidget{ /* init if needed*/ }
-    w.ExtendBaseWidget(w)
-    return w
+func NewMyListItemWidget(title, comment string) *MyListItemWidget {
+	item := &MyListItemWidget{
+		Title:   widget.NewLabel(title),
+		Comment: widget.NewLabel(comment),
+	}
+	item.Title.Truncation = fyne.TextTruncateEllipsis
+	item.ExtendBaseWidget(item)
+
+	return item
 }
 
-func (w *MyCustomWidget) CreateRenderer() fyne.WidgetRenderer {
-    c := container.NewWhatever(...) // do your layout here
-    return widget.NewSimpleRenderer(c)
+func (item *MyListItemWidget) CreateRenderer() fyne.WidgetRenderer {
+	c := container.NewBorder(nil, nil, nil, item.Comment, item.Title)
+	return widget.NewSimpleRenderer(c)
 }
 ```

--- a/extend/custom-widget.md
+++ b/extend/custom-widget.md
@@ -109,3 +109,28 @@ Take care not to keep any important state in your renderer - animation tickers
 are well suited to that location but user state would not be. A widget that is
 hidden may have it's renderer destroyed and if it is shown again the new renderer
 must be able to reflect the same widget state.
+
+#### Using SimpleRenderer for custom widgets
+
+The following pattern can used to wrap existing widgets using the
+`SimpleRenderer`. This allows for example to put a container in a custom widget
+and change the content dynamically, and many more things are possible following
+this approach.
+
+```go
+type MyCustomWidget struct
+    widget.BaseWidget
+    // all your widget's state, including its sub-widgets
+}
+
+func NewMyCustomWidget() *MyCustomWidget {
+    w := &MyCustomWidget{ /* init if needed*/ }
+    w.ExtendBaseWidget(w)
+    return w
+}
+
+func (w *MyCustomWidget) CreateRenderer() fyne.WidgetRenderer {
+    c := container.NewWhatever(...) // do your layout here
+    return widget.NewSimpleRenderer(c)
+}
+```

--- a/extend/custom-widget.md
+++ b/extend/custom-widget.md
@@ -112,11 +112,8 @@ must be able to reflect the same widget state.
 
 #### Using SimpleRenderer for custom widgets
 
-The following pattern can used to wrap existing widgets using the
-`SimpleRenderer`. This allows for example to put a container in a custom widget
-and change the content dynamically, and many more things are possible following
-this approach.
-
+Custom widgets built from a single `CanvasObject`, for example a container wrapping,
+multiple builtin widgets, can be implemented using `SimpleRenderer`.
 Below example is a custom widget that can be used as item in a list view,
 showing a title on the left hand side that will be truncated when too long, and
 a comment on the right hand side. The constructor would be called from the


### PR DESCRIPTION
This came up in fyne-io/fyne#4401 and addresses the underlying aspect of making custom widgets easier and more obvious.